### PR TITLE
Add shell path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Run your [Ceedling](https://github.com/ThrowTheSwitch/Ceedling) tests using the
 * Install the extension and restart VS Code
 * Open the workspace or folder containing your Ceedling project
 * Configure your `project.yml` path in the VS Code's settings if required [see below](#options)
+* Configure the shell path where ceedling is installed in the VS Code's settings if required (It might be required on Windows) [see below](#options)
 * Enable the `xml_tests_report` Ceedling plugin in your `project.yml` [see the ceedling doc](https://github.com/ThrowTheSwitch/Ceedling/blob/master/docs/CeedlingPacket.md#tool-element-runtime-substitution-notational-substitution)
 * Open the Test view
 * Run your tests using the ![Run](img/run.png) icons in the Test Explorer or the CodeLenses in your test file
@@ -30,6 +31,7 @@ Run your [Ceedling](https://github.com/ThrowTheSwitch/Ceedling) tests using the
 Property                        | Description
 --------------------------------|---------------------------------------------------------------
 `ceedlingExplorer.projectPath`  | The path to the ceedling project (where the `project.yml` is) to use (relative to the workspace folder). By default (or if this option is set to `null`) it use the same path as the workspace folder.
+`ceedlingExplorer.shellPath`    | The path to the shell where ceedling is installed. By default (or if this option is set to `null`) it use the OS default shell.
 
 ## Commands
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-ceedling-test-adapter",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
         "ceedlingExplorer.projectPath": {
           "description": "Path to the ceedling project directory",
           "type": "string",
+          "default": ".",
           "scope": "resource"
         },
         "ceedlingExplorer.shellPath": {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,12 @@
           "description": "Path to the ceedling project directory",
           "type": "string",
           "scope": "resource"
+        },
+        "ceedlingExplorer.shellPath": {
+          "description": "Path to the shell where ceedling is installed",
+          "type": "string",
+          "default": "null",
+          "scope": "resource"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "displayName": "Ceedling Test Explorer",
   "description": "Run your Ceedling tests in the Sidebar of Visual Studio Code",
   "icon": "img/icon.png",
-	"author": {
-		"name": "Kin Numaru"
-	},
+  "author": {
+    "name": "Kin Numaru"
+  },
   "publisher": "numaru",
   "version": "1.0.0",
   "license": "MIT",

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -435,7 +435,7 @@ export class CeedlingAdapter implements TestAdapter {
             /* Delete the xml report from the artifacts */
             await this.deleteXmlReport();
             /* Run the test and get stdout */
-            const result = await this.execCeedling([`test:${testSuite.file}`]);
+            const result = await this.execCeedling([`test:${testSuite.label}`]);
             const xmlReportData = await this.getXmlReportData();
             if (xmlReportData === undefined) {
                 /* The tests are not run so return fail */

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -125,6 +125,24 @@ export class CeedlingAdapter implements TestAdapter {
     }
 
     private async sanityCheck() {
+        const release = await this.ceedlingMutex.acquire();
+        try {
+            const result = await this.execCeedling([`summary`]);
+            if (result.error) {
+                vscode.window.showErrorMessage(
+                    `Ceedling failed to run in the configured shell. ` +
+                    `Please check the ceedlingExplorer.shellPath option.`
+                )
+            }
+            if (result.stderr.includes(`Could not find command "summary".`)) {
+                vscode.window.showErrorMessage(
+                    `Ceedling failed to run the project. ` +
+                    `Please check the ceedlingExplorer.projectPath option.`
+                )
+            }
+        } finally {
+            release();
+        }
         const ymlProjectData = await this.getYmlProjectData();
         if (ymlProjectData) {
             try {


### PR DESCRIPTION
Add an option to select an alternative shell where ceedling is installed (mostly for windows users).

Tested with wsl.

This is the correct version (to develop) of #5