### PR TITLE
Fix failing unit tests unable to be debugged

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -123,11 +123,7 @@ export class CeedlingAdapter implements TestAdapter {
             const testToExec = testSuites[0].id;
 
             // Execute ceedling test compilation
-            const result = await this.execCeedling([`test:${testToExec}`]);
-            if (result.error) {
-                vscode.window.showErrorMessage("Could not compile test, see test output for more details.");
-                return;
-            }
+            await this.execCeedling([`test:${testToExec}`]);
 
             // Set current test executable
             this.debugTestExecutable = `${/([^/]*).c$/.exec(testToExec)![1]}.out`;

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -123,7 +123,11 @@ export class CeedlingAdapter implements TestAdapter {
             const testToExec = testSuites[0].id;
 
             // Execute ceedling test compilation
-            await this.execCeedling([`test:${testToExec}`]);
+            const result = await this.execCeedling([`test:${testToExec}`]);
+            if (result.error && /ERROR: Ceedling Failed/.test(result.stdout)) {
+                vscode.window.showErrorMessage("Could not compile test, see test output for more details.");
+                return;
+            }
 
             // Set current test executable
             this.debugTestExecutable = `${/([^/]*).c$/.exec(testToExec)![1]}.out`;


### PR DESCRIPTION
Ceedling exits `-1` for failing unit tests. This presently prevents debug from being launched for failing unit ests. 