### PR TITLE
Detect xml report path from project.yml

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -27,6 +27,7 @@ export class CeedlingAdapter implements TestAdapter {
 
     private ceedlingProcess: child_process.ChildProcess | undefined;
     private functionRegex: RegExp | undefined;
+    private reportFilename: string = '';
     private watchedFileForAutorunList: string[] = [];
     private watchedFileForReloadList: string[] = [];
     private testSuiteInfo: TestSuiteInfo = {
@@ -72,6 +73,7 @@ export class CeedlingAdapter implements TestAdapter {
         }
 
         const ymlProjectData = await this.getYmlProjectData();
+        this.setXmlReportPath(ymlProjectData)
         this.setFunctionRegex(ymlProjectData);
         this.watchFilesForReload([this.getYmlProjectPath()]);
 
@@ -287,6 +289,16 @@ export class CeedlingAdapter implements TestAdapter {
         );
     }
 
+    private setXmlReportPath(ymlProjectData: any = undefined) {
+        let reportFilename = 'report.xml';
+        if (ymlProjectData) {
+            try {
+                reportFilename = ymlProjectData[':xml_tests_report'][':artifact_filename'];
+            } catch (e) { }
+        }
+        this.reportFilename = reportFilename;
+    }
+
     private getTestFunctionRegex(): RegExp {
         if (!this.functionRegex) {
             this.setFunctionRegex();
@@ -424,7 +436,7 @@ export class CeedlingAdapter implements TestAdapter {
     private getXmlReportPath(): string {
         return path.resolve(
             this.getProjectPath(),
-            'build', 'artifacts', 'test', 'report.xml'
+            'build', 'artifacts', 'test', this.reportFilename
         );
     }
 


### PR DESCRIPTION
https://github.com/ThrowTheSwitch/Ceedling/pull/324 Allowed for configuring the report filename path. 

This scans the `project.yml` for that configuration and uses it as the xml report path, otherwise defaults to `report.xml` as before.