### PR TITLE
Fix no tests appearing when :unity used in project configuration

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -280,7 +280,9 @@ export class CeedlingAdapter implements TestAdapter {
         let testPrefix = 'test|spec|should';
         if (ymlProjectData) {
             try {
-                testPrefix = ymlProjectData[':unity'][':test_prefix'];
+                let ymlProjectTestPrefix = ymlProjectData[':unity'][':test_prefix'];
+                if (ymlProjectTestPrefix != undefined)
+                    testPrefix = ymlProjectTestPrefix
             } catch (e) { }
         }
         this.functionRegex = new RegExp(


### PR DESCRIPTION
Fix no tests appearing when :unity is defined, but not :test_prefix is not in the Ceedling project configuration YAML.

Ex: 
```
:unity:
  :defines:
    - UNITY_INCLUDE_DOUBLE
```