### PR TITLE
Detect build directory from project.yml

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -75,7 +75,7 @@ export class CeedlingAdapter implements TestAdapter {
 
         const ymlProjectData = await this.getYmlProjectData();
         this.setBuildDirectory(ymlProjectData);
-        this.setXmlReportPath(ymlProjectData)
+        this.setXmlReportPath(ymlProjectData);
         this.setFunctionRegex(ymlProjectData);
         this.watchFilesForReload([this.getYmlProjectPath()]);
 

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -27,6 +27,7 @@ export class CeedlingAdapter implements TestAdapter {
 
     private ceedlingProcess: child_process.ChildProcess | undefined;
     private functionRegex: RegExp | undefined;
+    private buildDirectory: string = '';
     private reportFilename: string = '';
     private watchedFileForAutorunList: string[] = [];
     private watchedFileForReloadList: string[] = [];
@@ -73,6 +74,7 @@ export class CeedlingAdapter implements TestAdapter {
         }
 
         const ymlProjectData = await this.getYmlProjectData();
+        this.setBuildDirectory(ymlProjectData);
         this.setXmlReportPath(ymlProjectData)
         this.setFunctionRegex(ymlProjectData);
         this.watchFilesForReload([this.getYmlProjectPath()]);
@@ -289,6 +291,16 @@ export class CeedlingAdapter implements TestAdapter {
         );
     }
 
+    private setBuildDirectory(ymlProjectData: any = undefined) {
+        let buildDirectory = 'build';
+        if (ymlProjectData) {
+            try {
+                buildDirectory = ymlProjectData[':project'][':build_root'];
+            } catch (e) { }
+        }
+        this.buildDirectory = buildDirectory;
+    }
+
     private setXmlReportPath(ymlProjectData: any = undefined) {
         let reportFilename = 'report.xml';
         if (ymlProjectData) {
@@ -436,7 +448,7 @@ export class CeedlingAdapter implements TestAdapter {
     private getXmlReportPath(): string {
         return path.resolve(
             this.getProjectPath(),
-            'build', 'artifacts', 'test', this.reportFilename
+            this.buildDirectory, 'artifacts', 'test', this.reportFilename
         );
     }
 


### PR DESCRIPTION
Now the extension does not take into account the `build_root` project configuration variable, which leads to incorrect path to `report.xml`. This PR addresses the issue.

The patch has not been tested.

Thank you for the extension!