### PR TITLE
The vscode multi dir projects cannot debug tests

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -39,7 +39,6 @@ export class CeedlingAdapter implements TestAdapter {
     };
     private isCanceled: boolean = false;
     private ceedlingMutex: async_mutex.Mutex = new async_mutex.Mutex();
-    public debugTestExecutable: string = "";
 
     get tests(): vscode.Event<TestLoadStartedEvent | TestLoadFinishedEvent> {
         return this.testsEmitter.event;
@@ -138,7 +137,7 @@ export class CeedlingAdapter implements TestAdapter {
             const ext = this.getExecutableExtension(ymlProjectData);
 
             // Set current test executable
-            this.debugTestExecutable = `${/([^/]*).c$/.exec(testToExec)![1]}${ext}`;
+            g_debugTestExecutable = `${/([^/]*).c$/.exec(testToExec)![1]}${ext}`;
 
             // Launch debugger
             if (!await vscode.debug.startDebugging(this.workspaceFolder, debugConfiguration))
@@ -146,7 +145,7 @@ export class CeedlingAdapter implements TestAdapter {
         }
         finally {
             // Reset current test executable
-            this.debugTestExecutable = "";
+            g_debugTestExecutable = "";
         }
     }
 
@@ -560,4 +559,10 @@ export class CeedlingAdapter implements TestAdapter {
         }
         this.testStatesEmitter.fire({ type: 'suite', suite: testSuite, state: 'completed' } as TestSuiteEvent);
     }
+}
+
+let g_debugTestExecutable: string = "";
+
+export function getDebugTestExecutable(): string {
+    return g_debugTestExecutable;
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,12 +1,11 @@
 import * as vscode from 'vscode';
 import { TestHub, testExplorerExtensionId } from 'vscode-test-adapter-api';
 import { TestAdapterRegistrar } from 'vscode-test-adapter-util';
-import { CeedlingAdapter } from './adapter';
+import { CeedlingAdapter, getDebugTestExecutable } from './adapter';
 
-let currentAdapter: CeedlingAdapter | null = null;
 
 function getCurrentDebugConfiguration(): string {
-    const currentExec = currentAdapter != null ? currentAdapter!.debugTestExecutable : "";
+    const currentExec = getDebugTestExecutable();
     if (!currentExec) {
         vscode.window.showErrorMessage("Not currently debugging a Ceedling Test");
         return "";
@@ -21,8 +20,7 @@ export async function activate(context: vscode.ExtensionContext) {
         context.subscriptions.push(new TestAdapterRegistrar(
             testExplorerExtension.exports,
             workspaceFolder => {
-                currentAdapter = new CeedlingAdapter(workspaceFolder);
-                return currentAdapter;
+                return new CeedlingAdapter(workspaceFolder);
             }
         ));
     }


### PR DESCRIPTION
A VSCode workspace with more than one directory cannot debug a test
using the command ceedlingExplorer.debugTestExecutable. A pop-up
appear containing the path to the debug executable without the last
part.

This commit fix the bug by using a global variable, common to every
CeedlingAdapter, to store the name of the currently debugged
executable.

fix #27