### PR TITLE
Add  a testCommandArgs option to be able to run gcov

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Property                                | Description
 `ceedlingExplorer.debugConfiguration`   | The Debug configuration to run during debugging. See Debugging for more info.  
 `ceedlingExplorer.prettyTestLabel`      | The test label is prettier in the test explorer, that mean the label is shorter and without begin prefix. E.g. inactive `test_BlinkTaskShouldToggleLed`, active `BlinkTaskShouldToggleLed` <br> Inactive: <br> ![prettyTestLabelInactive](img/prettyTestLabelInactive.png) <br> Active: <br> ![prettyTestLabelActive](img/prettyTestLabelActive.png)
 `ceedlingExplorer.prettyTestFileLabel`  | The test file label is prettier in the test explorer, that mean the label is shorter, without begin prefix, path and file type. E.g. inactive `test/LEDs/test_BlinkTask.c`, active `BlinkTask` <br> Inactive: <br> ![prettyTestFileLabelInactive](img/prettyTestFileLabelInactive.png) <br> Active: <br> ![prettyTestFileLabelActive](img/prettyTestFileLabelActive.png)
+`ceedlingExplorer.testCommandArgs`      | The command line arguments used to run ceedling tests. The first argument have to litteraly contain the `${TEST_ID}` tag. The value `["test:${TEST_ID}"]` is used by default. For example, the arguments `"test:${TEST_ID}", "gcov:${TEST_ID}", "utils:gcov"` can be used to run tests and generate a gcov report.
 
 ## Commands
 

--- a/package.json
+++ b/package.json
@@ -93,6 +93,14 @@
           "type": "boolean",
           "default": true,
           "scope": "resource"
+        },
+        "ceedlingExplorer.testCommandArgs": {
+          "markdownDescription": "The command line arguments used to run the ceedling tests",
+          "type": "array",
+          "default": [
+            "test:${TEST_ID}"
+          ],
+          "scope": "resource"
         }
       }
     }

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -226,10 +226,12 @@ export class CeedlingAdapter implements TestAdapter {
     private getProjectPath(): string {
         const defaultProjectPath = '.';
         const projectPath = this.getConfiguration().get<string>('projectPath', defaultProjectPath);
-        return path.resolve(
-            this.workspaceFolder.uri.fsPath,
-            projectPath !== "null" ? projectPath : defaultProjectPath
-        );
+        let workspacePath = this.workspaceFolder.uri.fsPath;
+        // Workaround: Uppercase disk letters are required on windows to be able to generate xml gcov reports
+        if (process.platform == 'win32') {
+            workspacePath = workspacePath.charAt(0).toUpperCase() + workspacePath.slice(1);
+        }
+        return path.resolve(workspacePath, projectPath !== "null" ? projectPath : defaultProjectPath);
     }
 
     private async getFileList(fileType: string): Promise<string[]> {

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -65,7 +65,7 @@ export class CeedlingAdapter implements TestAdapter {
         // callback receive when a config property is modified
         vscode.workspace.onDidChangeConfiguration(event => {
             let affectedPrettyTestLabel = event.affectsConfiguration("ceedlingExplorer.prettyTestLabel");
-            let affectedPrettyTestFileLabel= event.affectsConfiguration("ceedlingExplorer.prettyTestFileLabel");
+            let affectedPrettyTestFileLabel = event.affectsConfiguration("ceedlingExplorer.prettyTestFileLabel");
             if (affectedPrettyTestLabel || affectedPrettyTestFileLabel) {
                this.load();
             }
@@ -407,7 +407,7 @@ export class CeedlingAdapter implements TestAdapter {
         return this.testLabelRegex as RegExp;
     }
 
-    private setTestLabel(testName: string): string | undefined{
+    private setTestLabel(testName: string): string | undefined {
         let testLabel = testName;
         if (this.isPrettyTestLabelEnable) {
             const labelFunctionRegex = this.getTestLabelRegex();
@@ -419,7 +419,7 @@ export class CeedlingAdapter implements TestAdapter {
         return testLabel;
     }
 
-    private setFileLabel(fileName : string): string {
+    private setFileLabel(fileName: string): string {
         let fileLabel = fileName;
         if (this.isPrettyTestFileLabelEnable) {
             const labelFileRegex = this.getFileLabelRegex();

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -67,7 +67,7 @@ export class CeedlingAdapter implements TestAdapter {
             let affectedPrettyTestLabel = event.affectsConfiguration("ceedlingExplorer.prettyTestLabel");
             let affectedPrettyTestFileLabel = event.affectsConfiguration("ceedlingExplorer.prettyTestFileLabel");
             if (affectedPrettyTestLabel || affectedPrettyTestFileLabel) {
-               this.load();
+                this.load();
             }
         })
     }
@@ -140,7 +140,8 @@ export class CeedlingAdapter implements TestAdapter {
             const testToExec = testSuites[0].id;
 
             // Execute ceedling test compilation
-            const result = await this.execCeedling([`test:${testToExec}`]);
+            const args = this.getTestCommandArgs(testToExec);
+            const result = await this.execCeedling(args);
             if (result.error && /ERROR: Ceedling Failed/.test(result.stdout)) {
                 vscode.window.showErrorMessage("Could not compile test, see test output for more details.");
                 return;
@@ -250,8 +251,16 @@ export class CeedlingAdapter implements TestAdapter {
     }
 
     private getCeedlingCommand(args: ReadonlyArray<string>) {
-        const line = `ceedling ${args}`;
+        const line = `ceedling ${args.join(" ")}`;
         return line;
+    }
+
+    private getTestCommandArgs(testToExec: string): Array<string> {
+        const defaultTestCommandArgs = ["test:${TEST_ID}"];
+        const testCommandArgs = this.getConfiguration()
+            .get<Array<string>>('testCommandArgs', defaultTestCommandArgs)
+            .map(x => x.replace("${TEST_ID}", testToExec));
+        return testCommandArgs;
     }
 
     private getExecutableExtension(ymlProjectData: any = undefined) {
@@ -441,7 +450,7 @@ export class CeedlingAdapter implements TestAdapter {
         /* get labels configuration */
         this.isPrettyTestFileLabelEnable = this.getConfiguration().get<boolean>('prettyTestFileLabel', false);
         this.isPrettyTestLabelEnable = this.getConfiguration().get<boolean>('prettyTestLabel', false);
-        
+
         for (const file of files) {
             const fullPath = path.resolve(this.getProjectPath(), file);
             const fileLabel = this.setFileLabel(file);
@@ -617,7 +626,8 @@ export class CeedlingAdapter implements TestAdapter {
             /* Delete the xml report from the artifacts */
             await this.deleteXmlReport();
             /* Run the test and get stdout */
-            const result = await this.execCeedling([`test:${testSuite.label}`]);
+            const args = this.getTestCommandArgs(testSuite.label);
+            const result = await this.execCeedling(args);
             const xmlReportData = await this.getXmlReportData();
             if (xmlReportData === undefined) {
                 /* The tests are not run so return fail */


### PR DESCRIPTION
It should fix #48.

---

I have been able to use the [Coverare Gutters](https://marketplace.visualstudio.com/items?itemName=ryanluker.vscode-coverage-gutters) extension on Windows.

**settings.json**
```json
{
    "ceedlingExplorer.testCommandArgs": [
        "test:${TEST_ID}",
        "gcov:${TEST_ID}",
        "utils:gcov"
    ],
    "coverage-gutters.xmlname": "GcovCoverageResults.xml",
    "coverage-gutters.coverageReportFileName": "**/GcovCoverageResults.html",
}
```

and after installing gcovr as described in the [ceedling documentation](https://github.com/ThrowTheSwitch/Ceedling/tree/master/plugins/gcov) I added the following lines to my ceedling project file.

**project.yml**:
```yaml
:gcov:
  :html_report: true
  :xml_report: true
```

![image](https://user-images.githubusercontent.com/23616600/79790347-deaeb980-834b-11ea-9b89-062d15ac53aa.png)
