### PR TITLE
Fix of double autorun triggering on test file save

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -100,7 +100,6 @@ export class CeedlingAdapter implements TestAdapter {
         this.watchFilesForAutorun(assemblyFiles);
         this.watchFilesForAutorun(headerFiles);
         this.watchFilesForAutorun(sourceFiles);
-        this.watchFilesForAutorun(testFiles);
 
         this.watchFilesForReload(testFiles);
 


### PR DESCRIPTION
Currently saving of test_\*.c file triggers autorun twice. This is because the same files (test_\*.c) watched both for autorun event emitting and for reload, but reload emits TestLoadFinishedEvent which triggers autorun.

See note in description of TestAdapter.autorun field.