### PR TITLE
Implement clobber and clean commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ The following commands are available in VS Code's command palette, use the ID to
 
 ID                                 | Command
 -----------------------------------|--------------------------------------------
+`ceedlingExplorer.clean`           | Run `ceedling clean`
+`ceedlingExplorer.clobber`         | Run `ceedling clobber`
 `test-explorer.reload`             | Reload tests
 `test-explorer.run-all`            | Run all tests
 `test-explorer.run-file`           | Run tests in current file

--- a/package.json
+++ b/package.json
@@ -205,6 +205,16 @@
           }
         }
       }
-    }
+    },
+    "commands": [
+      {
+        "command": "ceedlingExplorer.clean",
+        "title": "Ceedling: Clean"
+      },
+      {
+        "command": "ceedlingExplorer.clobber",
+        "title": "Ceedling: Clobber"
+      }
+    ]
   }
 }

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -179,6 +179,44 @@ export class CeedlingAdapter implements TestAdapter {
         }
     }
 
+    async clean(): Promise<void> {
+        const result = await vscode.window.withProgress(
+            {
+                title: "Ceedling Clean",
+                cancellable: true,
+                location: vscode.ProgressLocation.Notification,
+            }, async (progress, token) => {
+                token.onCancellationRequested(() => {
+                    this.cancel();
+                });
+
+                return this.execCeedling(["clean"]);
+            }
+        );
+        if (result.error) {
+            vscode.window.showErrorMessage("Ceedling clean failed");
+        }
+    }
+
+    async clobber(): Promise<void> {
+        const result = await vscode.window.withProgress(
+            {
+                title: "Ceedling Clobber",
+                cancellable: true,
+                location: vscode.ProgressLocation.Notification,
+            }, async (progress, token) => {
+                token.onCancellationRequested(() => {
+                    this.cancel();
+                });
+
+                return this.execCeedling(["clobber"]);
+            }
+        );
+        if (result.error) {
+            vscode.window.showErrorMessage("Ceedling clobber failed");
+        }
+    }
+
     cancel(): void {
         this.isCanceled = true;
         if (this.ceedlingProcess !== undefined) {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { TestHub, testExplorerExtensionId } from 'vscode-test-adapter-api';
 import { TestAdapterRegistrar } from 'vscode-test-adapter-util';
 import { CeedlingAdapter, getDebugTestExecutable } from './adapter';
 
+let currentAdapter: CeedlingAdapter | null = null
 
 function getCurrentDebugConfiguration(): string {
     const currentExec = getDebugTestExecutable();
@@ -13,14 +14,29 @@ function getCurrentDebugConfiguration(): string {
     return currentExec;
 }
 
+function ceedlingClean(): void {
+    if (currentAdapter != null) {
+        currentAdapter.clean();
+    }
+}
+
+function ceedlingClobber(): void {
+    if (currentAdapter != null) {
+        currentAdapter.clobber();
+    }
+}
+
 export async function activate(context: vscode.ExtensionContext) {
     const testExplorerExtension = vscode.extensions.getExtension<TestHub>(testExplorerExtensionId);
     if (testExplorerExtension) {
         context.subscriptions.push(vscode.commands.registerCommand("ceedlingExplorer.debugTestExecutable", getCurrentDebugConfiguration));
+        context.subscriptions.push(vscode.commands.registerCommand("ceedlingExplorer.clean", ceedlingClean));
+        context.subscriptions.push(vscode.commands.registerCommand("ceedlingExplorer.clobber", ceedlingClobber));
         context.subscriptions.push(new TestAdapterRegistrar(
             testExplorerExtension.exports,
             workspaceFolder => {
-                return new CeedlingAdapter(workspaceFolder);
+                currentAdapter = new CeedlingAdapter(workspaceFolder);
+                return currentAdapter;
             }
         ));
     }


### PR DESCRIPTION
Add two new commands `Ceedling: Clean` and `Ceedling: Clobber`. This can be used in case the tests' build fails and need to be cleaned or clobbered. The commands are cancelable.

![image](https://user-images.githubusercontent.com/5658563/103379742-aeabde80-4ab4-11eb-9aa1-63f0e68d9a66.png)

![image](https://user-images.githubusercontent.com/5658563/103379758-b9667380-4ab4-11eb-8e7d-342f4d31bb32.png)

