### PR TITLE
Hotfix/1.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.8.2] - 2021-04-21
+
+### Fixed
+
+* Choose the right report.xml when using gcov.
+
 ## [1.8.1] - 2021-02-17
 
 ### Fixed
@@ -134,10 +140,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 * Initial features
 
-[Unreleased]: https://github.com/numaru/vscode-ceedling-test-adapter/compare/v1.8.1...develop
-[1.6.0]: https://github.com/numaru/vscode-ceedling-test-adapter/compare/v1.8.0...v1.8.1
-[1.6.0]: https://github.com/numaru/vscode-ceedling-test-adapter/compare/v1.7.0...v1.8.0
-[1.6.0]: https://github.com/numaru/vscode-ceedling-test-adapter/compare/v1.6.0...v1.7.0
+[Unreleased]: https://github.com/numaru/vscode-ceedling-test-adapter/compare/v1.8.2...develop
+[1.8.2]: https://github.com/numaru/vscode-ceedling-test-adapter/compare/v1.8.1...v1.8.2
+[1.8.1]: https://github.com/numaru/vscode-ceedling-test-adapter/compare/v1.8.0...v1.8.1
+[1.8.0]: https://github.com/numaru/vscode-ceedling-test-adapter/compare/v1.7.0...v1.8.0
+[1.7.0]: https://github.com/numaru/vscode-ceedling-test-adapter/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/numaru/vscode-ceedling-test-adapter/compare/v1.5.1...v1.6.0
 [1.5.2]: https://github.com/numaru/vscode-ceedling-test-adapter/compare/v1.5.1...v1.5.2
 [1.5.1]: https://github.com/numaru/vscode-ceedling-test-adapter/compare/v1.5.0...v1.5.1

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "name": "Kin Numaru"
   },
   "publisher": "numaru",
-  "version": "1.8.1",
+  "version": "1.8.2",
   "license": "MIT",
   "homepage": "https://github.com/numaru/vscode-ceedling-test-adapter",
   "repository": {


### PR DESCRIPTION
Use the last udpated report.xml file as XmlReportPath because the file
is generated in a `gcov` subfolder when `ceedling gcov:*` is used.

fix #81