### PR TITLE
:construction_worker: Fix the release version name

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -48,7 +48,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: ${{ steps.changelog_reader.outputs.version }}
+        tag_name: v${{ steps.changelog_reader.outputs.version }}
         release_name: Release ${{ steps.changelog_reader.outputs.version }}
         body: ${{ steps.changelog_reader.outputs.changes }}
         prerelease: ${{ steps.changelog_reader.outputs.status == 'prereleased' }}


### PR DESCRIPTION
Add a `v` in front of the tag name of the release to avoid to create two
tags for a single release.