### PR TITLE
:sparkles: Add an option to remove the ascii escape sequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Property                                | Description
 `ceedlingExplorer.problemMatching`      | Configuration of compiler/linker problem matching. See [Problem matching](#problem%20matching) section for details.
 `ceedlingExplorer.testCaseMacroAliases` | An array of aliases for the `TEST_CASE` macro. By default it is `["TEST_CASE"]`
 `ceedlingExplorer.testRangeMacroAliases`| An array of aliases for the `TEST_RANGE` macro. By default it is `["TEST_RANGE"]`
+`ceedlingExplorer.asciiEscapeSequencesRemoved`| Should the ascii escape sequences be removed from ceedling stdout and stderr. By default it is `true`
 <br>
 
 ### Problem matching

--- a/package.json
+++ b/package.json
@@ -225,6 +225,12 @@
             "TEST_RANGE"
           ],
           "scope": "resource"
+        },
+        "ceedlingExplorer.asciiEscapeSequencesRemoved": {
+          "markdownDescription": "Should the ascii escape sequences be removed from ceedling stdout and stderr",
+          "type": "boolean",
+          "default": true,
+          "scope": "resource"
         }
       }
     },

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -370,6 +370,12 @@ export class CeedlingAdapter implements TestAdapter {
                     shell: this.getShellPath(),
                 },
                 (error, stdout, stderr) => {
+                    const asciiEscapeSequencesRemoved = this.getConfiguration().get<boolean>('asciiEscapeSequencesRemoved', true);
+                    if (asciiEscapeSequencesRemoved) {
+                        // Remove ascii colors from the outputs
+                        stdout = stdout.replace(/\u001B\[[;\d]*m/g, "");
+                        stderr = stderr.replace(/\u001B\[[;\d]*m/g, "");
+                    }
                     resolve({ error, stdout, stderr });
                 },
             )


### PR DESCRIPTION
The escape sequences are not evaluated by the OUTPUT panel. We should
remove them. I let an option to re-enable them if one day it's somehow
supported by vscode.

fix #102