### PR TITLE
:bug: Use only the file name in test:{TEST_ID} commands 

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -250,7 +250,7 @@ export class CeedlingAdapter implements TestAdapter {
         this.isCanceled = true;
         if (this.ceedlingProcess !== undefined) {
             if (this.ceedlingProcess.pid) {
-            tree_kill(this.ceedlingProcess.pid);
+                tree_kill(this.ceedlingProcess.pid);
             }
         }
     }
@@ -342,10 +342,12 @@ export class CeedlingAdapter implements TestAdapter {
     }
 
     private getTestCommandArgs(testToExec: string): Array<string> {
+        // Keep only the filename of the test 'test/test_foo.c' -> 'test_foo.c'
+        const testSuiteFilename = testToExec.replace(/^.*[\\/]/, "");
         const defaultTestCommandArgs = ["test:${TEST_ID}"];
         const testCommandArgs = this.getConfiguration()
             .get<Array<string>>('testCommandArgs', defaultTestCommandArgs)
-            .map(x => x.replace("${TEST_ID}", testToExec));
+            .map(x => x.replace("${TEST_ID}", testSuiteFilename));
         return testCommandArgs;
     }
 
@@ -806,7 +808,7 @@ export class CeedlingAdapter implements TestAdapter {
             /* Delete the xml report from the artifacts */
             await this.deleteXmlReport();
             /* Run the test and get stdout */
-            const args = this.getTestCommandArgs(testSuite.id.replace(/::.*/, ''));
+            const args = this.getTestCommandArgs(testSuite.id);
             const result = await this.execCeedling(args);
             const message: string = `stdout:\n${result.stdout}` + ((result.stderr.length != 0) ? `\nstderr:\n${result.stderr}` : ``);
 

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -249,7 +249,9 @@ export class CeedlingAdapter implements TestAdapter {
         this.logger.trace(`cancel()`);
         this.isCanceled = true;
         if (this.ceedlingProcess !== undefined) {
+            if (this.ceedlingProcess.pid) {
             tree_kill(this.ceedlingProcess.pid);
+            }
         }
     }
 
@@ -712,7 +714,7 @@ export class CeedlingAdapter implements TestAdapter {
     }
 
     private getYmlProjectData(): Promise<any | undefined> {
-        return new Promise<void>((resolve) => {
+        return new Promise<any | undefined>((resolve) => {
             fs.readFile(this.getYmlProjectPath(), 'utf8', (error, data) => {
                 if (error) {
                     resolve(undefined);


### PR DESCRIPTION
It's written in the ceedling code and help command that only the file
name should be used, not a path.

fix #120 