### PR TITLE
Feat additionnal project yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,11 +78,11 @@
           "scope": "resource"
         },
         "ceedlingExplorer.projectCustom": {
-					"markdownDescription": "Optionnal YAML file, configuration of this file will be merged with the main project file (project.yml) at runtime. Example `your_config.yml` will be used as `ceedling project:your_config.yml` usefull to add specific compiler configurations",
-					"type": "string",
-					"default": "null",
-					"scope": "resource"
-				},
+          "markdownDescription": "Optionnal YAML file, configuration of this file will be merged with the main project file (project.yml) at runtime. Example `your_config.yml` will be used as `ceedling project:your_config.yml` usefull to add specific compiler configurations",
+          "type": "string",
+          "default": "null",
+          "scope": "resource"
+          },
         "ceedlingExplorer.shellPath": {
           "description": "Path to the shell where Ceedling is installed",
           "type": "string",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,12 @@
           "default": ".",
           "scope": "resource"
         },
+        "ceedlingExplorer.projectCustom": {
+					"markdownDescription": "Optionnal YAML file, configuration of this file will be merged with the main project file (project.yml) at runtime. Example `your_config.yml` will be used as `ceedling project:your_config.yml` usefull to add specific compiler configurations",
+					"type": "string",
+					"default": "null",
+					"scope": "resource"
+				},
         "ceedlingExplorer.shellPath": {
           "description": "Path to the shell where Ceedling is installed",
           "type": "string",

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -302,6 +302,11 @@ export class CeedlingAdapter implements TestAdapter {
         return shellPath !== "null" ? shellPath : undefined;
     }
 
+    private getProjectCustom(): string {
+        const projectCustom = this.getConfiguration().get('projectCustom', 'null');
+        return projectCustom !== "null" ? projectCustom : "";
+    }
+
     private getProjectPath(): string {
         const defaultProjectPath = '.';
         const projectPath = this.getConfiguration().get<string>('projectPath', defaultProjectPath);
@@ -337,7 +342,9 @@ export class CeedlingAdapter implements TestAdapter {
     }
 
     private getCeedlingCommand(args: ReadonlyArray<string>) {
-        const line = `ceedling ${args.join(" ")}`;
+        const projectCustom = this.getProjectCustom();
+        const project = projectCustom ? `project:${projectCustom} ` : '';
+        const line = `ceedling ${project}${args.join(" ")}`;
         return line;
     }
 


### PR DESCRIPTION
Fix #117 

Add a feature to use Ceedling `project:` argument in order to allow to merge/load custom configuration from an additional `project_specific.yml` to the main `project.yml`.

This is usefull to test on different compiler or for different hardware as you can keep you common settings on main project.yml and use multiple specific.yml files to changes flags, defines... at runtime.