### PR TITLE
:sparkles: Add debug compatibility for ceedling >= v0.32.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "@types/js-yaml": "^3.12.0",
+        "@types/semver": "^7.5.4",
         "@types/xml2js": "^0.4.3",
         "async-mutex": "^0.1.3",
         "js-yaml": "^3.13.1",
+        "semver": "^7.5.4",
         "strip-ansi": "^6.0.0",
         "tree-kill": "^1.2.2",
         "tslib": "^1.9.3",
@@ -77,6 +79,11 @@
       "dependencies": {
         "undici-types": "~5.26.4"
       }
+    },
+    "node_modules/@types/semver": {
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.6.tgz",
+      "integrity": "sha512-dn1l8LaMea/IjDoHNd9J52uBbInB796CDffS6VdIxvqYCPSG0V0DzHp76GpaWnlhg88uYyPbXCDIowa86ybd5A=="
     },
     "node_modules/@types/vscode": {
       "version": "1.84.2",
@@ -1332,7 +1339,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -1961,7 +1967,6 @@
       "version": "7.5.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
       "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -2397,8 +2402,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
       "version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,11 @@
   },
   "dependencies": {
     "@types/js-yaml": "^3.12.0",
+    "@types/semver": "^7.5.4",
     "@types/xml2js": "^0.4.3",
     "async-mutex": "^0.1.3",
     "js-yaml": "^3.13.1",
+    "semver": "^7.5.4",
     "strip-ansi": "^6.0.0",
     "tree-kill": "^1.2.2",
     "tslib": "^1.9.3",


### PR DESCRIPTION
The path to the debug executable was computed depending on some `project.yml` options. It's not a big deal to depend also on the ceedling version.

fix: #118
duplicate: #124