### PR TITLE
fix ceedling (>=1.0.0) version regex

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -388,7 +388,7 @@ export class CeedlingAdapter implements TestAdapter {
 
     private async getCeedlingVersion(): Promise<string> {
         const result = await this.execCeedling(['version']);
-        const regex = new RegExp('Ceedling => (.*)$|Ceedling:: *(.*)$', 'gm');
+        const regex = new RegExp('Ceedling => *([\d\.]*)$|Ceedling:: *([\d\.]*)$', 'gm');
         const match = regex.exec(result.stdout);
         if (!match) {
             this.logger.error(`fail to get the ceedling version: ${util.format(result)}`);

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -388,7 +388,7 @@ export class CeedlingAdapter implements TestAdapter {
 
     private async getCeedlingVersion(): Promise<string> {
         const result = await this.execCeedling(['version']);
-        const regex = new RegExp('^\\s*Ceedling::\\s*(.*)$', 'gm');
+        const regex = new RegExp('Ceedling => (.*)$|Ceedling:: *(.*)$', 'gm');
         const match = regex.exec(result.stdout);
         if (!match) {
             this.logger.error(`fail to get the ceedling version: ${util.format(result)}`);


### PR DESCRIPTION
In Ceedling version 0.32 or 1.0 the output of the version command was changed from
```
  Ceedling::   0.28.3
```
```
    Ceedling:: 0.31.1
```
to
```
       Ceedling => 0.32.0
```

i changed the regex for getting the version from ceedling to work (hopefully) with all three outputs